### PR TITLE
Avoid unnecessary character copies in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![Build Status](https://travis-ci.org/kvark/copyless.svg)](https://travis-ci.org/kvark/copyless)
 [![Crates.io](https://img.shields.io/crates/v/copyless.svg)](https://crates.io/crates/copyless)
 
-Rust abstractions can be zero cost in theory, but offten reveal quite a few unnecessary `memcpy` calls in practice. This library provides a number of trait extensions for standard containers that expose API that is more friendly to LLVM optimization passes and doesn't end up with as many copies.
+Rust abstractions can be zero cost in theory, but often reveal quite a few unnecessary `memcpy` calls in practice. This library provides a number of trait extensions for standard containers that expose API that is more friendly to LLVM optimization passes and doesn't end up with as many copies.
 
 It aims to accelerate [WebRender](https://github.com/servo/webrender) and [gfx-rs](https://github.com/gfx-rs/gfx).
 
 ## Background
 
-The `memcpy` instructions showed in profiles of WebRender running in Gecko. @jrmuizel built a tool called [memcpy-find](https://github.com/jrmuizel/memcpy-find) that analyzes LLVM IR and spews out the call stacks that end up producing `memcpy` instructions. We figured out a way to convince the compiler to eliminate the copies. This library attemts to make these ways available to Rust ecosystem, at least until the compiler gets smart enough ;)
+The `memcpy` instructions showed in profiles of WebRender running in Gecko. @jrmuizel built a tool called [memcpy-find](https://github.com/jrmuizel/memcpy-find) that analyzes LLVM IR and spews out the call stacks that end up producing `memcpy` instructions. We figured out a way to convince the compiler to eliminate the copies. This library attempts to make these ways available to Rust ecosystem, at least until the compiler gets smart enough ;)
 
 ## Here is a small example
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -43,9 +43,9 @@ impl<'a, T> VecEntry<'a, T> {
 
 /// Helper trait for a `Vec` type that allocates up-front.
 pub trait VecHelper<T> {
-    /// Growns the vector by a single entry, returning the allocation.
+    /// Grows the vector by a single entry, returning the allocation.
     fn alloc(&mut self) -> VecAllocation<T>;
-    /// Either returns an existing elemenet, or grows the vector by one.
+    /// Either returns an existing element, or grows the vector by one.
     /// Doesn't expect indices to be higher than the current length.
     fn entry(&mut self, index: usize) -> VecEntry<T>;
 }


### PR DESCRIPTION
 (typo fixes)